### PR TITLE
Fix API when extending the keyResolver in cached key resolver.

### DIFF
--- a/DataHubClient.js
+++ b/DataHubClient.js
@@ -1088,12 +1088,12 @@ function _findRecipient(recipients, recipient) {
 
 function _createCachedKeyResolver(keyResolver) {
   const cache = {};
-  return async id => {
+  return async ({id}) => {
     let key = cache[id];
     if(key) {
       return key;
     }
-    key = await keyResolver(id);
+    key = await keyResolver({id});
     if(key) {
       cache[id] = key;
     }


### PR DESCRIPTION
Ensures we properly dereference keys in cached mode.

We can either accept this change or change the usage of `keyResolver` in minimal-cipher.
https://github.com/digitalbazaar/minimal-cipher/blob/master/Cipher.js#L226-L227

* Failure to adhere to the proper API results in unexpected caching
  behavior of keys.
* Downstream minimal-cipher expects to destruct the `id` property.